### PR TITLE
WIP - Update for 2.80 

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2,7 +2,7 @@ bl_info = {
     'name':     'BakeMyScan',
     'category': 'Object',
     'version': (1, 1, 0),
-    'blender': (2, 79, 0),
+    'blender': (2, 80, 0),
     "description": "Multipurpose add-on to texture, remesh and bake objects",
     "author": "Loïc NORGEOT",
     "warning": "Materials and baking operators are only available in Cycles",

--- a/scripts/bakemyscan.py
+++ b/scripts/bakemyscan.py
@@ -164,7 +164,7 @@ if __name__ == "__main__":
     bpy.ops.object.shade_smooth()
 
     #Bake
-    original.select=True
+    original.select_set(True)
     bpy.ops.bakemyscan.bake_textures(
         resolution    = args.resolution,
         bake_albedo   = args.color is not None,
@@ -178,6 +178,6 @@ if __name__ == "__main__":
     )
 
     #Export
-    original.select = False
+    original.select_set(False)
     bpy.ops.bakemyscan.remove_all_but_selected()
     bpy.ops.bakemyscan.export(filepath=args.output, compress=args.zip)

--- a/scripts/batch_processing/blender_import_models_on_grid.py
+++ b/scripts/batch_processing/blender_import_models_on_grid.py
@@ -42,7 +42,7 @@ for m in models:
     #Import the model and make it active
     bpy.ops.bakemyscan.import_scan(filepath = os.path.join(args.input, m))
     obj = [o for o in bpy.data.objects if o.select][0]
-    bpy.context.scene.objects.active = obj
+    bpy.context.view_layer.objects.active = obj
     obj.name = name
 
     #Try to create a material from a texture

--- a/src/GUI.py
+++ b/src/GUI.py
@@ -8,7 +8,7 @@ from . import fn_nodes
 class BakeMyScanPanel(bpy.types.Panel):
     """A base class for panels to inherit"""
     bl_space_type  = "VIEW_3D"
-    bl_region_type = "TOOLS"
+    bl_region_type = "UI"
     bl_category    = "BakeMyScan"
     bl_options     = {"DEFAULT_CLOSED"}
     bl_context     = "objectmode"
@@ -65,54 +65,55 @@ class BakeMyScanProperties(bpy.types.PropertyGroup):
         return None
 
     #Delighting properties
-    delight = bpy.props.BoolProperty(description="Delighting", default=False, update=toggle_delight)
-    delight_invert_factor = bpy.props.FloatProperty(description="Inversion factor for delighting", default=0.3, min=0.,max=1., update=update_delight_invert)
-    delight_ao_factor = bpy.props.FloatProperty(description="Ambient Occlusion factor for delighting", default=0.15, min=0.,max=1., update=update_delight_ao)
+    delight: bpy.props.BoolProperty(description="Delighting", default=False, update=toggle_delight)
+    delight_invert_factor: bpy.props.FloatProperty(description="Inversion factor for delighting", default=0.3, min=0.,max=1., update=update_delight_invert)
+    delight_ao_factor: bpy.props.FloatProperty(description="Ambient Occlusion factor for delighting", default=0.15, min=0.,max=1., update=update_delight_ao)
     #General material properties
-    ao_factor = bpy.props.FloatProperty(description="Ambient Occlusion factor", default=0.5, min=0.,max=1., update=update_ao)
-    uv_scale = bpy.props.FloatProperty(description="UV scale", default=1, min=0.,max=1000., update=update_UV_scale)
-    height = bpy.props.FloatProperty(description="Height", default=0.005, min=-1.,max=1., update=update_height)
+    ao_factor: bpy.props.FloatProperty(description="Ambient Occlusion factor", default=0.5, min=0.,max=1., update=update_ao)
+    uv_scale: bpy.props.FloatProperty(description="UV scale", default=1, min=0.,max=1000., update=update_UV_scale)
+    height: bpy.props.FloatProperty(description="Height", default=0.005, min=-1.,max=1., update=update_height)
     #HDRI properties
-    intensity =  bpy.props.FloatProperty(description="HDRI intensity", default=1, min=0., max=10000., update=setworldintensity)
-    visibility = bpy.props.BoolProperty(description="HDRI visibility", default=False, update=toggle_hdri)
-    rotation =  bpy.props.FloatProperty(description="HDRI rotation", default=0., min=-1., max=1., update=rotate_hdri)
+    intensity: bpy.props.FloatProperty(description="HDRI intensity", default=1, min=0., max=10000., update=setworldintensity)
+    visibility: bpy.props.BoolProperty(description="HDRI visibility", default=False, update=toggle_hdri)
+    rotation: bpy.props.FloatProperty(description="HDRI rotation", default=0., min=-1., max=1., update=rotate_hdri)
     #Scanning images
-    imagesdirectory = bpy.props.StringProperty(description="Filepath used for importing the file",subtype='DIR_PATH', update=update_scan_images)
+    imagesdirectory: bpy.props.StringProperty(description="Filepath used for importing the file",subtype='DIR_PATH', update=update_scan_images)
     #PBR library
-    texturepath =  bpy.props.StringProperty(description="Filepath used for importing the file",subtype='DIR_PATH',update=create_PBR_library)
+    texturepath: bpy.props.StringProperty(description="Filepath used for importing the file",subtype='DIR_PATH',update=create_PBR_library)
 
-class ScanPanel(BakeMyScanPanel):
+class SCAN_PT_Panel(BakeMyScanPanel):
     """A panel for the scanning methods"""
     bl_label       = "Structure from Motion"
     def draw(self, context):
         box = self.layout
-        box.label("Images directory")
+        box.label(text="Images directory")
         box.prop(context.scene.bakemyscan_properties, "imagesdirectory", text="")
-        box.label("Structure from motion")
+        box.label(text="Structure from motion")
         #box.operator("bakemyscan.colmap_auto", icon="CAMERA_DATA", text="Colmap auto")
         box.operator("bakemyscan.colmap_openmvs", icon="CAMERA_DATA", text="Colmap OpenMVS Meshlab")
 
-class PipelinePanel(BakeMyScanPanel):
+class PIPELINE_PT_Panel(BakeMyScanPanel):
     bl_label = "Model optimization"
     def draw(self, context):
         self.layout.operator("bakemyscan.clean_object", icon="PARTICLEMODE", text="Pre-process")
 
-        self.layout.label("Retopology")
+        self.layout.label(text="Retopology")
         self.layout.operator("bakemyscan.full_pipeline", icon="MOD_DECIM", text="Remesh")
         self.layout.operator("bakemyscan.unwrap",            icon="GROUP_UVS",  text="Unwrap")
 
-        self.layout.label("Post-process")
+        self.layout.label(text="Post-process")
 
         self.layout.operator("bakemyscan.symetrize",         icon="MOD_MIRROR", text='Symmetry')
         self.layout.operator("bakemyscan.relax",             icon="MOD_SMOKE",  text='Relax!')
         self.layout.operator("bakemyscan.manifold",          icon="MOD_FLUIDSIM",  text='Manifold')
         self.layout.operator("bakemyscan.remove_all_but_selected", icon="X", text="Clean non selected data")
 
-        self.layout.label("Texture baking")
+        self.layout.label(text="Texture baking")
         self.layout.operator("bakemyscan.bake_textures",         icon="TEXTURE", text="Bake textures")
+        self.layout.operator("bakemyscan.bake_textures_nodes",         icon="TEXTURE", text="Bake textures w Nodes")
         self.layout.operator("bakemyscan.bake_to_vertex_colors", icon="COLOR",   text="Albedo to Vertex color")
 
-class MaterialPanel(BakeMyScanPanel):
+class MATERIAL_PT_Panel(BakeMyScanPanel):
     bl_label       = "Material / Textures"
 
     @classmethod
@@ -131,7 +132,7 @@ class MaterialPanel(BakeMyScanPanel):
             row = layout.row()
             lab = row.row()
             lab.scale_x = 1.0
-            lab.label(name)
+            lab.label(text=name)
             sub=row.row()
             sub.scale_x=4.0
             sub.template_ID(data=node,property="image",open="image.open")
@@ -153,7 +154,7 @@ class MaterialPanel(BakeMyScanPanel):
 
         #Display a warning
         if ob is None:
-            self.layout.label("No active object")
+            self.layout.label(text="No active object")
 
         #Display the material selector widget
         if ob is not None and len(context.selected_objects)>0:
@@ -173,7 +174,7 @@ class MaterialPanel(BakeMyScanPanel):
                 row = box.row()
                 lab = row.row()
                 lab.scale_x = 1.0
-                lab.label("")
+                lab.label(text="")
                 sub=row.row()
                 sub.scale_x=4.0
                 sub.prop(context.scene.bakemyscan_properties, "ao_factor", text="Factor")
@@ -212,9 +213,9 @@ class MaterialPanel(BakeMyScanPanel):
                                     self.layout.prop(context.scene.bakemyscan_properties, "uv_scale", text="UV scale")
                                     self.layout.prop(context.scene.bakemyscan_properties, "height",   text="Height")
 
-class RemeshFromSculptPanel(bpy.types.Panel):
+class REMESHFROMSCULPT_PT_Panel(bpy.types.Panel):
     bl_space_type  = "VIEW_3D"
-    bl_region_type = "TOOLS"
+    bl_region_type = "UI"
     bl_category    = "Tools"
     bl_label       = "BakeMyScan"
     bl_context     = "sculpt_mode"
@@ -223,7 +224,7 @@ class RemeshFromSculptPanel(bpy.types.Panel):
     def draw(self, context):
         self.layout.operator("bakemyscan.full_pipeline", icon="MOD_DECIM", text="Retopology")
 
-class HDRIsPanel(BakeMyScanPanel):
+class HDRIS_PT_Panel(BakeMyScanPanel):
     """Creates a Panel in the Object properties window"""
     bl_label       = "HDRIs"
 
@@ -250,7 +251,7 @@ class HDRIsPanel(BakeMyScanPanel):
             layout.prop(context.scene.bakemyscan_properties, "intensity", text="Intensity")
             layout.prop(context.scene.bakemyscan_properties, "rotation", text="Rotation")
 
-class AboutPanel(BakeMyScanPanel):
+class ABOUT_PT_Panel(BakeMyScanPanel):
     bl_label       = "Updates / Help"
 
     def draw(self, context):
@@ -288,20 +289,20 @@ class AboutPanel(BakeMyScanPanel):
                     icon = bpy.types.Scene.custom_icons["bakemyscan"].icon_id
                     row.operator("wm.url_open", icon="INFO", text='Current: %s' % name, icon_value=icon).url = "https://github.com/norgeotloic/BakeMyScan/releases/tag/"+name
 
-        self.layout.label("Resources")
+        self.layout.label(text="Resources")
         self.layout.operator("wm.url_open", text="Tutorials", icon="QUESTION").url = "http://bakemyscan.org/tutorials"
         self.layout.operator("wm.url_open", text="BlenderArtists", icon="BLENDER").url = "https://blenderartists.org/t/bakemyscan-open-source-toolbox-for-asset-optimization"
         self.layout.operator("wm.url_open", text="Sketchfab", icon_value=bpy.types.Scene.custom_icons["sketchfab"].icon_id).url = "https://sketchfab.com/norgeotloic"
         self.layout.operator("wm.url_open", text="Twitter",   icon_value=bpy.types.Scene.custom_icons["tweeter"].icon_id).url = "https://twitter.com/norgeotloic"
         self.layout.operator("wm.url_open", text="Youtube",   icon_value=bpy.types.Scene.custom_icons["youtube"].icon_id).url = "https://youtube.com/norgeotloic"
 
-        self.layout.label("Development")
+        self.layout.label(text="Development")
         self.layout.operator("wm.url_open", text="Github",         icon_value=bpy.types.Scene.custom_icons["github"].icon_id).url = "http://github.com/norgeotloic/BakeMyScan"
         self.layout.operator("wm.url_open", text="Build status",   icon_value=bpy.types.Scene.custom_icons["travis"].icon_id).url = "https://travis-ci.org/norgeotloic/BakeMyScan"
         self.layout.operator("wm.url_open", text="Roadmap",   icon="SORTTIME").url = "http://github.com/norgeotloic/BakeMyScan/milestones"
         self.layout.operator("wm.url_open", text='"Blog"',    icon="WORDWRAP_ON").url = "http://bakemyscan.org/blog"
 
-        self.layout.label("External software")
+        self.layout.label(text="External software")
         self.layout.operator("wm.url_open", text="MMGtools", icon_value=bpy.types.Scene.custom_icons["mmg"].icon_id).url = "https://www.mmgtools.org/"
         self.layout.operator("wm.url_open", text="Instant Meshes", icon_value=bpy.types.Scene.custom_icons["instant"].icon_id).url = "https://github.com/wjakob/instant-meshes"
         self.layout.operator("wm.url_open", text="Quadriflow", icon="MOD_DECIM").url = "https://github.com/hjwdzh/QuadriFlow"
@@ -333,18 +334,18 @@ def register():
     bpy.types.Scene.bakemyscan_properties = bpy.props.PointerProperty(type=BakeMyScanProperties)
     bpy.types.Scene.imagesdirectory = ""
     #Panels
-    bpy.utils.register_class(ScanPanel)
-    bpy.utils.register_class(MaterialPanel)
-    bpy.utils.register_class(RemeshFromSculptPanel)
-    bpy.utils.register_class(PipelinePanel)
-    bpy.utils.register_class(HDRIsPanel)
-    bpy.utils.register_class(AboutPanel)
+    bpy.utils.register_class(SCAN_PT_Panel)
+    bpy.utils.register_class(MATERIAL_PT_Panel)
+    bpy.utils.register_class(REMESHFROMSCULPT_PT_Panel)
+    bpy.utils.register_class(PIPELINE_PT_Panel)
+    bpy.utils.register_class(HDRIS_PT_Panel)
+    bpy.utils.register_class(ABOUT_PT_Panel)
     #Menu options
-    bpy.types.INFO_MT_file_import.append(import_mesh_func)
-    bpy.types.INFO_MT_file_export.append(export_mesh_func)
-    bpy.types.INFO_MT_file_import.append(import_bms_func)
-    bpy.types.INFO_MT_file_export.append(export_bms_func)
-    bpy.types.INFO_MT_render.append(export_ortho_func)
+    bpy.types.TOPBAR_MT_file_import.append(import_mesh_func)
+    bpy.types.TOPBAR_MT_file_export.append(export_mesh_func)
+    bpy.types.TOPBAR_MT_file_import.append(import_bms_func)
+    bpy.types.TOPBAR_MT_file_export.append(export_bms_func)
+    bpy.types.TOPBAR_MT_render.append(export_ortho_func)
     #Node options
     bpy.types.NODE_MT_add.append(add_empty_pbr)
     bpy.types.NODE_MT_add.append(add_pbr_from_library)
@@ -355,18 +356,18 @@ def unregister():
     del bpy.types.Scene.bakemyscan_properties
     del bpy.types.Scene.imagesdirectory
     #Panels
-    bpy.utils.unregister_class(ScanPanel)
-    bpy.utils.unregister_class(MaterialPanel)
-    bpy.utils.unregister_class(RemeshFromSculptPanel)
-    bpy.utils.unregister_class(PipelinePanel)
-    bpy.utils.unregister_class(HDRIsPanel)
-    bpy.utils.unregister_class(AboutPanel)
+    bpy.utils.unregister_class(SCAN_PT_Panel)
+    bpy.utils.unregister_class(MATERIAL_PT_Panel)
+    bpy.utils.unregister_class(REMESHFROMSCULPT_PT_Panel)
+    bpy.utils.unregister_class(PIPELINE_PT_Panel)
+    bpy.utils.unregister_class(HDRIS_PT_Panel)
+    bpy.utils.unregister_class(ABOUT_PT_Panel)
     #Menu options
-    bpy.types.INFO_MT_file_import.remove(import_mesh_func)
-    bpy.types.INFO_MT_file_export.remove(export_mesh_func)
-    bpy.types.INFO_MT_file_import.remove(import_bms_func)
-    bpy.types.INFO_MT_file_export.remove(export_bms_func)
-    bpy.types.INFO_MT_render.remove(export_ortho_func)
+    bpy.types.TOPBAR_MT_file_import.remove(import_mesh_func)
+    bpy.types.TOPBAR_MT_file_export.remove(export_mesh_func)
+    bpy.types.TOPBAR_MT_file_import.remove(import_bms_func)
+    bpy.types.TOPBAR_MT_file_export.remove(export_bms_func)
+    bpy.types.TOPBAR_MT_render.remove(export_ortho_func)
     #Node options
     bpy.types.NODE_MT_add.remove(add_empty_pbr)
     bpy.types.NODE_MT_add.remove(add_pbr_from_library)

--- a/src/PREFS.py
+++ b/src/PREFS.py
@@ -75,21 +75,21 @@ class BakeMyScanPrefs(bpy.types.AddonPreferences):
 
     executables = {}
     #Remeshers
-    mmgs          = bpy.props.StringProperty(name="MMGS Executable", subtype='FILE_PATH', update=absolute_paths)
-    instant       = bpy.props.StringProperty(name="Instant Meshes Executable", subtype='FILE_PATH', update=absolute_paths)
-    quadriflow    = bpy.props.StringProperty(name="Quadriflow Executable", subtype='FILE_PATH', update=absolute_paths)
-    meshlabserver = bpy.props.StringProperty(name="Meshlabserver Executable", subtype='FILE_PATH', update=absolute_paths)
+    mmgs: bpy.props.StringProperty(name="MMGS Executable", subtype='FILE_PATH', update=absolute_paths)
+    instant: bpy.props.StringProperty(name="Instant Meshes Executable", subtype='FILE_PATH', update=absolute_paths)
+    quadriflow: bpy.props.StringProperty(name="Quadriflow Executable", subtype='FILE_PATH', update=absolute_paths)
+    meshlabserver: bpy.props.StringProperty(name="Meshlabserver Executable", subtype='FILE_PATH', update=absolute_paths)
     #Scanning executables
-    colmap        = bpy.props.StringProperty(name="Colmap Executable", subtype='FILE_PATH', update=absolute_paths)
-    openmvsdir    = bpy.props.StringProperty(name="OpenMVS directory", subtype='DIR_PATH', update=find_openmvs_executables)
+    colmap: bpy.props.StringProperty(name="Colmap Executable", subtype='FILE_PATH', update=absolute_paths)
+    openmvsdir: bpy.props.StringProperty(name="OpenMVS directory", subtype='DIR_PATH', update=find_openmvs_executables)
     #OpenMVS executables
-    interfacevisualsfm = bpy.props.StringProperty(name="InterfaceVisualSFM", subtype='FILE_PATH', update=absolute_paths)
-    densifypointcloud  = bpy.props.StringProperty(name="DensifyPointCloud", subtype='FILE_PATH', update=absolute_paths)
-    reconstructmesh    = bpy.props.StringProperty(name="ReconstructMesh", subtype='FILE_PATH', update=absolute_paths)
-    texturemesh        = bpy.props.StringProperty(name="TextureMesh", subtype='FILE_PATH', update=absolute_paths)
+    interfacevisualsfm: bpy.props.StringProperty(name="InterfaceVisualSFM", subtype='FILE_PATH', update=absolute_paths)
+    densifypointcloud: bpy.props.StringProperty(name="DensifyPointCloud", subtype='FILE_PATH', update=absolute_paths)
+    reconstructmesh: bpy.props.StringProperty(name="ReconstructMesh", subtype='FILE_PATH', update=absolute_paths)
+    texturemesh: bpy.props.StringProperty(name="TextureMesh", subtype='FILE_PATH', update=absolute_paths)
 
     #Texture library
-    texturepath =  bpy.props.StringProperty(description="PBR textures library", subtype='DIR_PATH', update=updatepath)
+    texturepath: bpy.props.StringProperty(description="PBR textures library", subtype='DIR_PATH', update=updatepath)
 
 
 
@@ -119,7 +119,7 @@ def register():
     bpy.types.Scene.pbrtextures = {}
     bpy.utils.register_class(BakeMyScanPrefs)
 
-    PREFS = bpy.context.user_preferences.addons["BakeMyScan"].preferences
+    PREFS = bpy.context.preferences.addons["BakeMyScan"].preferences
 
     #Try to read in the preferences from the saved file
     path = os.path.join(bpy.utils.resource_path('USER'), "bakemyscan.config")

--- a/src/fn_nodes.py
+++ b/src/fn_nodes.py
@@ -240,21 +240,27 @@ def node_tree_pbr():
     _ao_mix.location = [-200, 0]
     _vertexcolors.location = [-400,0]
     _metallic.location = [-200, -200]
-    _metallic.color_space = "NONE"
+    if _metallic.image:
+        _metallic.image.colorspace_settings.is_data = True
     _roughness.location = [-200, -400]
-    _roughness.color_space = "NONE"
+    if _roughness.image:
+        _roughness.image.colorspace_settings.is_data = True
     _glossiness.location = [-400, -400]
     _glossiness_invert.location = [-200, -400]
-    _glossiness.color_space = "NONE"
+    if _glossiness.image:
+        _glossiness.image.colorspace_settings.is_data = True
     _bump.location = [-200, -600]
     _nmap.location = [-400, -700]
     _height.location = [-400, -500]
     _normal.location = [-600, -700]
-    _normal.color_space = "NONE"
+    if _normal.image:
+        _normal.image.colorspace_settings.is_data = True
     _subsurface.location = [-200, -100]
-    _subsurface.color_space = "NONE"
+    if _subsurface.image:
+        _subsurface.image.colorspace_settings.is_data = True
     _transmission.location = [-200, -600]
-    _transmission.color_space = "NONE"
+    if _transmission.image:
+        _transmission.image.colorspace_settings.is_data = True
     #Post-shader emission and opacity mix
     _emission.location = [-200, 200]
     _emission_shader.location = [0, 200]

--- a/src/op_BAKING_bake.py
+++ b/src/op_BAKING_bake.py
@@ -13,7 +13,7 @@ def addImageNode(mat, nam, res):
     _image                     = bpy.data.images.new(nam, res, res)
     _imagenode                 = mat.node_tree.nodes.new(type="ShaderNodeTexImage") if not mat.node_tree.nodes.get("img") else mat.node_tree.nodes.get("img")
     _imagenode.name            = "img"
-    _imagenode.select          = True
+    _imagenode.select = True
     mat.node_tree.nodes.active = _imagenode
     _imagenode.image           = _image
     return _imagenode
@@ -22,9 +22,10 @@ def bakeWithBlender(mat, nam, res, _type="NORMALS"):
     #To blender internal
     restore = mat.use_nodes
     engine  = bpy.context.scene.render.engine
-    bpy.context.scene.render.engine="BLENDER_RENDER"
+    bpy.context.scene.render.engine="CYCLES"
     mat.use_nodes = False
-    bpy.context.scene.render.use_bake_to_vertex_color = False
+    # 3/2/19 - ES - Commenting out because can't find equivalent command in 2.8 API
+    # bpy.context.scene.render.use_bake_to_vertex_color = False
 
 
     if bpy.data.images.get(nam):
@@ -38,6 +39,7 @@ def bakeWithBlender(mat, nam, res, _type="NORMALS"):
         if mat.texture_slots[c] is not None:
             mat.texture_slots.clear(c)
     mtex = mat.texture_slots.add()
+
     mtex.texture = tex
     mtex.texture_coords = 'UV'
 
@@ -59,23 +61,25 @@ def bakeWithBlender(mat, nam, res, _type="NORMALS"):
     bpy.context.scene.render.engine=engine
     return image
 
+
+
 class bake_cycles_textures(bpy.types.Operator):
     bl_idname = "bakemyscan.bake_textures"
     bl_label  = "Textures to textures"
     bl_options = {"REGISTER", "UNDO"}
 
-    resolution     = bpy.props.IntProperty( name="resolution",     description="image resolution", default=1024, min=128, max=8192)
-    cageRatio      = bpy.props.FloatProperty(name="cageRatio",     description="baking cage size as a ratio", default=0.02, min=0.00001, max=5)
-    bake_albedo    = bpy.props.BoolProperty(name="bake_albedo",    description="albedo", default=True)
-    bake_ao        = bpy.props.BoolProperty(name="bake_ao",        description="ambient occlusion", default=False)
-    bake_geometry  = bpy.props.BoolProperty(name="bake_geometry",  description="geometric normals", default=True)
-    bake_surface   = bpy.props.BoolProperty(name="bake_surface",   description="material normals", default=False)
-    bake_metallic  = bpy.props.BoolProperty(name="bake_metallic",  description="metalness", default=False)
-    bake_roughness = bpy.props.BoolProperty(name="bake_roughness", description="roughness", default=False)
-    bake_transmission = bpy.props.BoolProperty(name="bake_transmission",  description="transmission", default=False)
-    bake_subsurface = bpy.props.BoolProperty(name="bake_subsurface",  description="subsurface", default=False)
-    bake_emission  = bpy.props.BoolProperty(name="bake_emission",  description="emission", default=False)
-    bake_opacity   = bpy.props.BoolProperty(name="bake_opacity",   description="opacity", default=False)
+    resolution: bpy.props.IntProperty( name="resolution",     description="image resolution", default=1024, min=128, max=8192)
+    cageRatio: bpy.props.FloatProperty(name="cageRatio",     description="baking cage size as a ratio", default=0.02, min=0.00001, max=5)
+    bake_albedo: bpy.props.BoolProperty(name="bake_albedo",    description="albedo", default=True)
+    bake_ao: bpy.props.BoolProperty(name="bake_ao",        description="ambient occlusion", default=False)
+    bake_geometry: bpy.props.BoolProperty(name="bake_geometry",  description="geometric normals", default=True)
+    bake_surface: bpy.props.BoolProperty(name="bake_surface",   description="material normals", default=False)
+    bake_metallic: bpy.props.BoolProperty(name="bake_metallic",  description="metalness", default=False)
+    bake_roughness: bpy.props.BoolProperty(name="bake_roughness", description="roughness", default=False)
+    bake_transmission: bpy.props.BoolProperty(name="bake_transmission",  description="transmission", default=False)
+    bake_subsurface: bpy.props.BoolProperty(name="bake_subsurface",  description="subsurface", default=False)
+    bake_emission: bpy.props.BoolProperty(name="bake_emission",  description="emission", default=False)
+    bake_opacity: bpy.props.BoolProperty(name="bake_opacity",   description="opacity", default=False)
 
     def invoke(self, context, event):
         return context.window_manager.invoke_props_dialog(self)
@@ -85,11 +89,11 @@ class bake_cycles_textures(bpy.types.Operator):
         box.prop(self, "resolution", text="Image resolution")
         box.prop(self, "cageRatio",  text="Relative cage size")
         box = self.layout.box()
-        box.label("PBR channels")
+        box.label(text="PBR channels")
         box.prop(self, "bake_albedo",    text="Albedo")
         box.prop(self, "bake_metallic",  text="Metallic")
         box.prop(self, "bake_roughness", text="Roughness")
-        box.label("Other channels")
+        box.label(text="Other channels")
         box.prop(self, "bake_geometry", text="Geometric normals")
         box.prop(self, "bake_surface",  text="Surface normals")
         box.prop(self, "bake_ao",       text="Ambient occlusion")
@@ -251,7 +255,7 @@ class bake_cycles_textures(bpy.types.Operator):
         #Init the material
         for o in context.selected_objects:
             if o!=context.active_object:
-                o.select=False
+                o.select_set(False)
         bpy.ops.bakemyscan.create_empty_material(name=prefix+"_material")
         for _type in importSettings:
             if importSettings[_type] is not None:

--- a/src/op_BAKING_bake_nodes.py
+++ b/src/op_BAKING_bake_nodes.py
@@ -111,7 +111,7 @@ class bake_cycles_textures_nodes(bpy.types.Operator):
         print("Baking finished in %f seconds." % (time.time() - t0))
 
         principledNode = mat.node_tree.nodes["Principled BSDF"]
-        links.new(principledNode.inputs["Base Color"], image_tex_node.outputs["Color"])
+        mat.node_tree.links.new(principledNode.inputs["Base Color"], image_tex_node.outputs["Color"])
 
         # self.report({'INFO'}, "Baking successful")
         return{'FINISHED'}

--- a/src/op_BAKING_bake_nodes.py
+++ b/src/op_BAKING_bake_nodes.py
@@ -1,0 +1,123 @@
+import bpy
+import os
+from . import fn_nodes
+from . import fn_soft
+from . import fn_bake
+import numpy as np
+import collections
+import time
+
+class bake_cycles_textures_nodes(bpy.types.Operator):
+    bl_idname = "bakemyscan.bake_textures_nodes"
+    bl_label  = "Textures to textures via nodes"
+    bl_options = {"REGISTER", "UNDO"}
+
+    resolution: bpy.props.IntProperty( name="resolution",     description="image resolution", default=1024, min=128, max=8192)
+    cageRatio: bpy.props.FloatProperty(name="cageRatio",     description="baking cage size as a ratio", default=0.02, min=0.00001, max=5)
+
+    def invoke(self, context, event):
+        return context.window_manager.invoke_props_dialog(self)
+
+    def draw(self, context):
+        box = self.layout.box()
+        box.prop(self, "resolution", text="Image resolution")
+        box.prop(self, "cageRatio",  text="Relative cage size")
+
+    @classmethod
+    def poll(self, context):
+        #Render engine must be cycles
+        if bpy.context.scene.render.engine!="CYCLES":
+            return 0
+        #Object mode
+        if context.mode!="OBJECT":
+            return 0
+        #If more than two objects are selected
+        if len(context.selected_objects)<2:
+            return 0
+        #If no object is active
+        if context.active_object is None:
+            return 0
+        #If something other than a MESH is selected
+        for o in context.selected_objects:
+            if o.type != "MESH":
+                return 0
+        #The source object must have correct materials
+        sources = [o for o in context.selected_objects if o!=context.active_object]
+        target = context.active_object
+
+        #Each material must be not None and have nodes
+        for source in sources:
+            if source.active_material is None:
+                return 0
+            if source.active_material.use_nodes == False:
+                return 0
+        #The target object must have a UV layout
+        # if len(target.data.uv_layers) == 0:
+        #     return 0
+        return 1
+
+
+    def execute(self, context):
+        #Find which object is the source and which is the target
+        target  = context.active_object
+        sources = [o for o in context.selected_objects if o!=target]
+
+        # Add new BDSF material
+        mat_name = 'LowPolyMat'
+        mat = bpy.data.materials.new(name=mat_name)
+        mat.use_nodes = True
+        if target.data.materials:
+            target.data.materials[0] = mat
+        else:
+            target.data.materials.append(mat)
+
+        # UV Unwrap
+        bpy.ops.object.select_all(action='DESELECT')
+        bpy.context.view_layer.objects.active = target
+        target.select_set(True)
+        bpy.ops.object.mode_set(mode='EDIT')
+        bpy.ops.mesh.select_mode(type="VERT")
+        bpy.ops.mesh.select_all(action = 'SELECT')
+        bpy.ops.mesh.uv_texture_add()
+        bpy.context.object.data.uv_layers["UVMap"].active_render = True
+        bpy.ops.uv.smart_project(angle_limit=66.0, island_margin=0.1)
+        print("Smart Projection complete.")
+        bpy.ops.object.mode_set(mode='OBJECT')
+
+        # # New image
+        imageName = 'img'
+        image = bpy.data.images.new(imageName, self.resolution, self.resolution)
+
+        # # Setup Image Texture Node
+        image_tex_node = mat.node_tree.nodes.new(type="ShaderNodeTexImage")
+        image_tex_node.image = image
+
+        bpy.ops.object.select_all(action='DESELECT')
+        sources[0].select_set(True)
+        target.select_set(True)
+        bpy.context.view_layer.objects.active = target
+
+        bpy.context.scene.render.engine = 'CYCLES'
+        bpy.context.scene.render.bake.use_selected_to_active = True
+        bpy.context.scene.cycles.bake_type = 'DIFFUSE'
+        bpy.context.scene.render.bake.cage_extrusion = self.cageRatio
+        bpy.context.scene.render.bake.use_pass_indirect = False
+        bpy.context.scene.render.bake.use_pass_direct = False
+
+        print("Baking...")
+        t0 = time.time()
+        bpy.ops.object.bake(type='DIFFUSE')
+
+        print("Baking finished in %f seconds." % (time.time() - t0))
+
+        principledNode = mat.node_tree.nodes["Principled BSDF"]
+        links.new(principledNode.inputs["Base Color"], image_tex_node.outputs["Color"])
+
+        # self.report({'INFO'}, "Baking successful")
+        return{'FINISHED'}
+
+def register() :
+    bpy.utils.register_class(bake_cycles_textures_nodes)
+
+def unregister() :
+    bpy.utils.unregister_class(bake_cycles_textures_nodes)

--- a/src/op_EXPORT_export.py
+++ b/src/op_EXPORT_export.py
@@ -10,13 +10,13 @@ class export(bpy.types.Operator, ExportHelper):
     bl_options = {"REGISTER", "UNDO"}
 
     filename_ext=".fbx"
-    filter_glob = bpy.props.StringProperty(
+    filter_glob: bpy.props.StringProperty(
         default="*.fbx;*.obj;*.ply",
         options={'HIDDEN'},
     )
 
-    fmt      = bpy.props.EnumProperty(items= ( ('PNG', 'PNG', 'PNG'), ("JPEG", "JPEG", "JPEG")) , name="fmt", description="Image format", default="JPEG")
-    compress = bpy.props.BoolProperty("compress", name="compress", description="Compress into a .zip", default=False)
+    fmt: bpy.props.EnumProperty(items= ( ('PNG', 'PNG', 'PNG'), ("JPEG", "JPEG", "JPEG")) , name="fmt", description="Image format", default="JPEG")
+    compress: bpy.props.BoolProperty("compress", name="compress", description="Compress into a .zip", default=False)
 
     @classmethod
     def poll(self, context):

--- a/src/op_EXPORT_ortho.py
+++ b/src/op_EXPORT_ortho.py
@@ -11,11 +11,11 @@ class export_orthoview(bpy.types.Operator, ExportHelper):
     bl_options = {"REGISTER", "UNDO"}
 
     filename_ext = ".png"
-    filter_glob = bpy.props.StringProperty(default="*.png", options={'HIDDEN'})
-    margin      = bpy.props.IntProperty(default=50, min=5,max=512)
-    resolution  = bpy.props.IntProperty(default=512, min=64,max=2048)
+    filter_glob: bpy.props.StringProperty(default="*.png", options={'HIDDEN'})
+    margin: bpy.props.IntProperty(default=50, min=5,max=512)
+    resolution: bpy.props.IntProperty(default=512, min=64,max=2048)
 
-    filepath = bpy.props.StringProperty(
+    filepath: bpy.props.StringProperty(
         name="Export ortho view",
         description="Image to export the view to",
         maxlen= 1024,

--- a/src/op_FULLPIPELINE.py
+++ b/src/op_FULLPIPELINE.py
@@ -29,71 +29,71 @@ class full_pipeline(bpy.types.Operator):
     bl_options = {"REGISTER", "UNDO"}
 
     #Quadriflow
-    quadriflow_resolution = bpy.props.IntProperty(description="Resolution", default=1000, min=10, max=100000 )
-    quadriflow_advanced = bpy.props.BoolProperty(description="advanced properties", default=False)
-    quadriflow_mincost  = bpy.props.BoolProperty(description="Min-Cost Flow Solver", default=False )
-    quadriflow_sharp    = bpy.props.BoolProperty(description="Preserve sharp edges", default=False )
-    quadriflow_satflip  = bpy.props.BoolProperty(description="SAT Flip Removal", default=False )
+    quadriflow_resolution: bpy.props.IntProperty(description="Resolution", default=1000, min=10, max=100000 )
+    quadriflow_advanced: bpy.props.BoolProperty(description="advanced properties", default=False)
+    quadriflow_mincost: bpy.props.BoolProperty(description="Min-Cost Flow Solver", default=False )
+    quadriflow_sharp: bpy.props.BoolProperty(description="Preserve sharp edges", default=False )
+    quadriflow_satflip: bpy.props.BoolProperty(description="SAT Flip Removal", default=False )
 
     #Instant
-    instant_interactive = bpy.props.BoolProperty(description="Interactive", default=False)
-    instant_method      = bpy.props.EnumProperty(items= ( ('faces', 'Number of faces', 'Number of faces'), ("verts", "Number of verts", "Number of verts"), ("edges", "Edge length", "Edge length")), description="Remesh according to", default="faces")
-    instant_facescount  = bpy.props.IntProperty(description="Number of faces", default=5000, min=10, max=10000000 )
-    instant_vertscount  = bpy.props.IntProperty(description="Number of verts", default=5000, min=10, max=10000000 )
-    instant_edgelength  = bpy.props.FloatProperty(description="Edge length (ratio)", default=0.05, min=0.001, max=1 )
-    instant_advanced = bpy.props.BoolProperty(description="advanced properties", default=False)
-    instant_d = bpy.props.BoolProperty(description="Deterministic (slower)", default=False)
-    instant_D = bpy.props.BoolProperty(description="Tris/quads dominant instead of pure", default=False)
-    instant_i = bpy.props.BoolProperty(description="Intrinsic mode", default=False)
-    instant_b = bpy.props.BoolProperty(description="Align to boundaries", default=False)
-    instant_C = bpy.props.BoolProperty(description="Compatibility mode", default=False)
-    instant_c = bpy.props.FloatProperty(description="Creases angle threshold", default=30, min=0, max=180 )
-    instant_S = bpy.props.IntProperty(description="Smoothing reprojection steps", default=2, min=0, max=100 )
-    instant_r = bpy.props.EnumProperty(items= ( ('r0', 'none', 'none'), ("2", "2", "2"), ("4", "4", "4"), ("6", "6", "6")) ,description="Orientation symmetry type", default="r0")
-    instant_p = bpy.props.EnumProperty(items= ( ('p0', 'none', 'none'), ("4", "4", "4"), ("6", "6", "6")) ,description="Position symmetry type", default="p0")
+    instant_interactive: bpy.props.BoolProperty(description="Interactive", default=False)
+    instant_method: bpy.props.EnumProperty(items= ( ('faces', 'Number of faces', 'Number of faces'), ("verts", "Number of verts", "Number of verts"), ("edges", "Edge length", "Edge length")), description="Remesh according to", default="faces")
+    instant_facescount: bpy.props.IntProperty(description="Number of faces", default=5000, min=10, max=10000000 )
+    instant_vertscount: bpy.props.IntProperty(description="Number of verts", default=5000, min=10, max=10000000 )
+    instant_edgelength: bpy.props.FloatProperty(description="Edge length (ratio)", default=0.05, min=0.001, max=1 )
+    instant_advanced: bpy.props.BoolProperty(description="advanced properties", default=False)
+    instant_d: bpy.props.BoolProperty(description="Deterministic (slower)", default=False)
+    instant_D: bpy.props.BoolProperty(description="Tris/quads dominant instead of pure", default=False)
+    instant_i: bpy.props.BoolProperty(description="Intrinsic mode", default=False)
+    instant_b: bpy.props.BoolProperty(description="Align to boundaries", default=False)
+    instant_C: bpy.props.BoolProperty(description="Compatibility mode", default=False)
+    instant_c: bpy.props.FloatProperty(description="Creases angle threshold", default=30, min=0, max=180 )
+    instant_S: bpy.props.IntProperty(description="Smoothing reprojection steps", default=2, min=0, max=100 )
+    instant_r: bpy.props.EnumProperty(items= ( ('r0', 'none', 'none'), ("2", "2", "2"), ("4", "4", "4"), ("6", "6", "6")) ,description="Orientation symmetry type", default="r0")
+    instant_p: bpy.props.EnumProperty(items= ( ('p0', 'none', 'none'), ("4", "4", "4"), ("6", "6", "6")) ,description="Position symmetry type", default="p0")
 
     #mmgs
-    mmgs_smooth = bpy.props.BoolProperty(description="Ignore angle detection (smooth)", default=True)
-    mmgs_hausd  = bpy.props.FloatProperty(description="Haussdorf distance (ratio)", default=0.01, min=0.0001, max=1)
-    mmgs_advanced = bpy.props.BoolProperty(description="advanced properties", default=False)
-    mmgs_angle  = bpy.props.FloatProperty(description="Angle detection (°)", default=30, min=0.01, max=180.)
-    mmgs_hmin   = bpy.props.FloatProperty(description="Minimal edge size (ratio)", default=0.005, min=0.0001, max=1)
-    mmgs_hmax   = bpy.props.FloatProperty(description="Maximal edge size (ratio)", default=0.05, min=0.0001, max=5)
-    mmgs_hgrad  = bpy.props.FloatProperty(description="Gradation parameter", default=1.3, min=1., max=5.)
-    mmgs_aniso  = bpy.props.BoolProperty(description="Enable anisotropy", default=False)
-    mmgs_nreg   = bpy.props.BoolProperty(description="Normal regulation", default=False)
-    mmgs_weight   = bpy.props.BoolProperty(description="weight as edge length", default=False)
+    mmgs_smooth: bpy.props.BoolProperty(description="Ignore angle detection (smooth)", default=True)
+    mmgs_hausd: bpy.props.FloatProperty(description="Haussdorf distance (ratio)", default=0.01, min=0.0001, max=1)
+    mmgs_advanced: bpy.props.BoolProperty(description="advanced properties", default=False)
+    mmgs_angle: bpy.props.FloatProperty(description="Angle detection (°)", default=30, min=0.01, max=180.)
+    mmgs_hmin: bpy.props.FloatProperty(description="Minimal edge size (ratio)", default=0.005, min=0.0001, max=1)
+    mmgs_hmax: bpy.props.FloatProperty(description="Maximal edge size (ratio)", default=0.05, min=0.0001, max=5)
+    mmgs_hgrad: bpy.props.FloatProperty(description="Gradation parameter", default=1.3, min=1., max=5.)
+    mmgs_aniso: bpy.props.BoolProperty(description="Enable anisotropy", default=False)
+    mmgs_nreg: bpy.props.BoolProperty(description="Normal regulation", default=False)
+    mmgs_weight: bpy.props.BoolProperty(description="weight as edge length", default=False)
 
     #meshlab
-    meshlab_facescount = bpy.props.IntProperty(description="Number of faces", default=5000, min=10, max=1000000 )
-    meshlab_advanced = bpy.props.BoolProperty(description="advanced properties", default=False)
-    meshlab_quality    = bpy.props.FloatProperty(description="Quality threshold", default=0.3, min=0., max=1. )
-    meshlab_boundaries = bpy.props.BoolProperty(description="Preserve boundary", default=False)
-    meshlab_weight     = bpy.props.FloatProperty(description="Boundary preserving weight", default=1., min=0., max=1. )
-    meshlab_normals  = bpy.props.BoolProperty(description="Preserve normals", default=False)
-    meshlab_topology = bpy.props.BoolProperty(description="Preserve topology", default=False)
-    meshlab_existing = bpy.props.BoolProperty(description="Use existing vertices", default=False)
-    meshlab_planar   = bpy.props.BoolProperty(description="Planar simplification", default=False)
-    meshlab_post     = bpy.props.BoolProperty(description="Post-process (isolated, duplicates...)", default=True)
+    meshlab_facescount: bpy.props.IntProperty(description="Number of faces", default=5000, min=10, max=1000000 )
+    meshlab_advanced: bpy.props.BoolProperty(description="advanced properties", default=False)
+    meshlab_quality: bpy.props.FloatProperty(description="Quality threshold", default=0.3, min=0., max=1. )
+    meshlab_boundaries: bpy.props.BoolProperty(description="Preserve boundary", default=False)
+    meshlab_weight: bpy.props.FloatProperty(description="Boundary preserving weight", default=1., min=0., max=1. )
+    meshlab_normals: bpy.props.BoolProperty(description="Preserve normals", default=False)
+    meshlab_topology: bpy.props.BoolProperty(description="Preserve topology", default=False)
+    meshlab_existing: bpy.props.BoolProperty(description="Use existing vertices", default=False)
+    meshlab_planar: bpy.props.BoolProperty(description="Planar simplification", default=False)
+    meshlab_post: bpy.props.BoolProperty(description="Post-process (isolated, duplicates...)", default=True)
 
     #Decimate
-    decim_limit    = bpy.props.IntProperty(description="Target faces", default=1500, min=50, max=500000)
-    decim_vertex_group = bpy.props.BoolProperty(description="Use vertex group", default=False)
-    decim_factor = bpy.props.FloatProperty(description="Weight factor", default=0.5, min=0., max=1.)
+    decim_limit: bpy.props.IntProperty(description="Target faces", default=1500, min=50, max=500000)
+    decim_vertex_group: bpy.props.BoolProperty(description="Use vertex group", default=False)
+    decim_factor: bpy.props.FloatProperty(description="Weight factor", default=0.5, min=0., max=1.)
 
     #Iterative
-    iter_limit    = bpy.props.IntProperty(description="Target faces", default=1500, min=50, max=500000)
-    iter_vertex_group  = bpy.props.BoolProperty(description="Use vertex group", default=False)
-    iter_factor = bpy.props.FloatProperty(description="Weight factor", default=0.5, min=0., max=1.)
+    iter_limit: bpy.props.IntProperty(description="Target faces", default=1500, min=50, max=500000)
+    iter_vertex_group: bpy.props.BoolProperty(description="Use vertex group", default=False)
+    iter_factor: bpy.props.FloatProperty(description="Weight factor", default=0.5, min=0., max=1.)
 
     #Quads
-    quads_nfaces = bpy.props.IntProperty(description="Decimate ratio",  default=1500, min=50, max=200000)
-    quads_smooth = bpy.props.IntProperty(description="Smoothing steps", default=1, min=0, max=15)
-    quads_vertex_group  = bpy.props.BoolProperty(description="Use vertex group", default=False)
-    quads_factor = bpy.props.FloatProperty(description="Weight factor", default=0.5, min=0., max=1.)
+    quads_nfaces: bpy.props.IntProperty(description="Decimate ratio",  default=1500, min=50, max=200000)
+    quads_smooth: bpy.props.IntProperty(description="Smoothing steps", default=1, min=0, max=15)
+    quads_vertex_group: bpy.props.BoolProperty(description="Use vertex group", default=False)
+    quads_factor: bpy.props.FloatProperty(description="Weight factor", default=0.5, min=0., max=1.)
 
     #Remeshing options
-    remeshing_method = bpy.props.EnumProperty(
+    remeshing_method: bpy.props.EnumProperty(
         items = available_methods_callback,
         description="Remeshing method",
     )
@@ -130,7 +130,7 @@ class full_pipeline(bpy.types.Operator):
                 box.prop(self, "quads_factor", text="Weight factor")
 
         elif self.remeshing_method == "quadriflow":
-            box.prop(self, "quadriflow_resolution", "Resolution")
+            box.prop(self, "quadriflow_resolution", text="Resolution")
             box = box.box()
             box.prop(self, "quadriflow_advanced", text="Advanced options")
             if self.quadriflow_advanced:
@@ -225,7 +225,7 @@ class full_pipeline(bpy.types.Operator):
 
     def execute(self, context):
 
-        
+
 
         if self.remeshing_method == "decimate":
             bpy.ops.bakemyscan.remesh_decimate(

--- a/src/op_IMPORT_clean.py
+++ b/src/op_IMPORT_clean.py
@@ -6,15 +6,15 @@ class clean_object(bpy.types.Operator):
     bl_label  = "Preprocess"
     bl_options = {"REGISTER", "UNDO"}
 
-    materials   = bpy.props.BoolProperty(name="materials",   description="Materials", default=True)
-    doubles     = bpy.props.BoolProperty(name="doubles",     description="Duplicate vertices", default=True)
-    loose       = bpy.props.BoolProperty(name="loose",       description="Loose geometry", default=True)
-    sharp       = bpy.props.BoolProperty(name="sharp",       description="Sharp", default=True)
-    normals     = bpy.props.BoolProperty(name="normals",     description="Normals", default=True)
-    center      = bpy.props.BoolProperty(name="center",      description="Center", default=True)
-    scale       = bpy.props.BoolProperty(name="scale",       description="Scale", default=True)
-    smooth      = bpy.props.IntProperty( name="smooth",      description="Smoothing iterations", default=0, min=0, max=50)
-    shade       = bpy.props.BoolProperty(name="shade",       description="Shade smooth", default=True)
+    materials: bpy.props.BoolProperty(name="materials",   description="Materials", default=True)
+    doubles: bpy.props.BoolProperty(name="doubles",     description="Duplicate vertices", default=True)
+    loose: bpy.props.BoolProperty(name="loose",       description="Loose geometry", default=True)
+    sharp: bpy.props.BoolProperty(name="sharp",       description="Sharp", default=True)
+    normals: bpy.props.BoolProperty(name="normals",     description="Normals", default=True)
+    center: bpy.props.BoolProperty(name="center",      description="Center", default=True)
+    scale: bpy.props.BoolProperty(name="scale",       description="Scale", default=True)
+    smooth: bpy.props.IntProperty( name="smooth",      description="Smoothing iterations", default=0, min=0, max=50)
+    shade: bpy.props.BoolProperty(name="shade",       description="Shade smooth", default=True)
 
     @classmethod
     def poll(cls, context):
@@ -30,14 +30,14 @@ class clean_object(bpy.types.Operator):
         return context.window_manager.invoke_props_dialog(self)
 
     def draw(self, context):
-        self.layout.label("Global")
+        self.layout.label(text="Global")
         self.layout.prop(self, "materials", text="Clean materials")
         self.layout.prop(self, "center",    text="Center the object")
         self.layout.prop(self, "scale",     text="Scale to unit box")
-        self.layout.label("Geometry")
+        self.layout.label(text="Geometry")
         self.layout.prop(self, "doubles",   text="Remove duplicated vertices")
         self.layout.prop(self, "loose",     text="Delete loose geometry")
-        self.layout.label("Normals")
+        self.layout.label(text="Normals")
         self.layout.prop(self, "sharp",     text="Remove sharp marks")
         self.layout.prop(self, "normals",   text="Normalize normals")
         self.layout.prop(self, "shade",    text="Shade smooth")
@@ -53,8 +53,8 @@ class clean_object(bpy.types.Operator):
 
             #Select the new mesh, and make it the active object
             bpy.ops.object.select_all(action='DESELECT')
-            obj.select = True
-            context.scene.objects.active = obj
+            obj.select_set(True)
+            context.view_layer.objects.active = obj
 
             #Remove the material slots
             if self.materials:

--- a/src/op_IMPORT_scan.py
+++ b/src/op_IMPORT_scan.py
@@ -6,7 +6,7 @@ class import_scan(bpy.types.Operator, ImportHelper):
     bl_idname = "bakemyscan.import_scan"
     bl_label  = "Import"
     bl_options = {"REGISTER", "UNDO"}
-    filter_glob = bpy.props.StringProperty(
+    filter_glob: bpy.props.StringProperty(
         default="*.obj;*.ply;*.stl;*.fbx;*.dae;*.x3d;*.wrl",
         options={'HIDDEN'},
     )
@@ -72,8 +72,8 @@ class import_scan(bpy.types.Operator, ImportHelper):
 
         #Select the new mesh, and make it the active object
         bpy.ops.object.select_all(action='DESELECT')
-        obj.select = True
-        context.scene.objects.active = obj
+        obj.select_set(True)
+        context.active_object = obj
 
         #Zoom on it
         for area in bpy.context.screen.areas:

--- a/src/op_MATERIALS_assign_texture.py
+++ b/src/op_MATERIALS_assign_texture.py
@@ -10,11 +10,11 @@ class assign_texture(bpy.types.Operator, ImportHelper):
     bl_label  = "Assign PBR textures to a material"
     bl_options = {"REGISTER", "UNDO"}
 
-    filter_glob = bpy.props.StringProperty(
+    filter_glob: bpy.props.StringProperty(
         default="*.png;*.jpg;*.jpeg;*.bmp;*.tif;*.tiff;*.exr",
         options={'HIDDEN'},
     )
-    slot = bpy.props.EnumProperty(
+    slot: bpy.props.EnumProperty(
         items= (
             ('albedo', 'albedo', 'albedo'),
             ("normal", "normal", "normal"),
@@ -33,7 +33,7 @@ class assign_texture(bpy.types.Operator, ImportHelper):
         default="albedo"
     )
 
-    byname = bpy.props.BoolProperty(name="byname", description="pass images by name instead of files", default=False)
+    byname: bpy.props.BoolProperty(name="byname", description="pass images by name instead of files", default=False)
 
     @classmethod
     def poll(self, context):

--- a/src/op_MATERIALS_create_library.py
+++ b/src/op_MATERIALS_create_library.py
@@ -9,7 +9,7 @@ class create_library(bpy.types.Operator):
     bl_label  = "List available materials"
     bl_options = {"REGISTER", "UNDO"}
 
-    filepath = bpy.props.StringProperty(
+    filepath: bpy.props.StringProperty(
         name="filepath",
         description="Filepath used for importing the file",
         maxlen=1024,

--- a/src/op_MATERIALS_empty.py
+++ b/src/op_MATERIALS_empty.py
@@ -18,7 +18,7 @@ class create_empty_material(bpy.types.Operator):
     bl_label  = "Creates an empty PBR material"
     bl_options = {"REGISTER", "UNDO"}
 
-    name = bpy.props.StringProperty(name="name", default="PBR", description="Material name")
+    name: bpy.props.StringProperty(name="name", default="PBR", description="Material name")
 
     @classmethod
     def poll(self, context):
@@ -65,7 +65,7 @@ class create_empty_node(bpy.types.Operator):
     bl_label  = "Creates an empty PBR node"
     bl_options = {"REGISTER", "UNDO"}
 
-    name = bpy.props.StringProperty(name="name", default="PBR", description="Material name")
+    name: bpy.props.StringProperty(name="name", default="PBR", description="Material name")
 
     @classmethod
     def poll(self, context):
@@ -89,7 +89,7 @@ class create_empty_node(bpy.types.Operator):
         #Select the group and link it to the mouse for better placement
         for n in mat.node_tree.nodes:
             n.select = False
-        _group.select = True
+        _group.select_set(True)
         _group.location = context.space_data.cursor_location
         mat.node_tree.nodes.active = _group
         bpy.ops.node.translate_attach_remove_on_cancel('INVOKE_DEFAULT')

--- a/src/op_MATERIALS_from_library.py
+++ b/src/op_MATERIALS_from_library.py
@@ -13,7 +13,7 @@ class material_from_library(bpy.types.Operator):
     bl_options = {"REGISTER", "UNDO"}
     bl_property = "enum"
 
-    enum = bpy.props.EnumProperty(
+    enum: bpy.props.EnumProperty(
         name="PBR textures",
         description="",
         items=get_materials_list_callback
@@ -55,7 +55,7 @@ class node_from_library(bpy.types.Operator):
     bl_options = {"REGISTER", "UNDO"}
     bl_property = "enum"
 
-    enum = bpy.props.EnumProperty(
+    enum: bpy.props.EnumProperty(
         name="PBR textures",
         description="",
         items=get_materials_list_callback

--- a/src/op_MATERIALS_from_texture.py
+++ b/src/op_MATERIALS_from_texture.py
@@ -11,7 +11,7 @@ class material_from_texture(bpy.types.Operator, ImportHelper):
     bl_label  = "Load material from texture"
     bl_options = {"REGISTER", "UNDO"}
 
-    filter_glob = bpy.props.StringProperty(
+    filter_glob: bpy.props.StringProperty(
         default="*.png;*.jpg;*.jpeg;*.bmp;*.tif;*.tiff;*.exr",
         options={'HIDDEN'},
     )

--- a/src/op_MATERIALS_load_JSON.py
+++ b/src/op_MATERIALS_load_JSON.py
@@ -10,7 +10,7 @@ class load_json_library(bpy.types.Operator, ImportHelper):
     bl_options = {"REGISTER", "UNDO"}
 
     bl_label  = "Material library from .json"
-    filter_glob = bpy.props.StringProperty(
+    filter_glob: bpy.props.StringProperty(
         default="*.json",
         options={'HIDDEN'},
     )

--- a/src/op_MATERIALS_save_JSON.py
+++ b/src/op_MATERIALS_save_JSON.py
@@ -10,7 +10,7 @@ class save_json_library(bpy.types.Operator, ExportHelper):
     bl_options = {"REGISTER", "UNDO"}
 
     filename_ext=".json"
-    filter_glob = bpy.props.StringProperty(default="*.json", options={'HIDDEN'})
+    filter_glob: bpy.props.StringProperty(default="*.json", options={'HIDDEN'})
 
     @classmethod
     def poll(self, context):

--- a/src/op_MATERIALS_unwrap.py
+++ b/src/op_MATERIALS_unwrap.py
@@ -6,7 +6,7 @@ class unwrap(bpy.types.Operator):
     bl_label  = "Unwrap the model"
     bl_options = {"REGISTER", "UNDO"}
 
-    method = bpy.props.EnumProperty(
+    method: bpy.props.EnumProperty(
         items= (
             ('basic',   'Basic unwrapping',   'Basic unwrapping'),
             ("smart",   "Smart UV project",   "Smart UV project"),

--- a/src/op_MESH_export.py
+++ b/src/op_MESH_export.py
@@ -12,13 +12,13 @@ class export_mesh(bpy.types.Operator, ExportHelper):
     bl_label  = "Exports a .mesh file"
 
     #ExportHelper settings
-    filter_glob = bpy.props.StringProperty(
+    filter_glob: bpy.props.StringProperty(
         default="*.mesh",
         options={'HIDDEN'},
     )
     check_extension = True
     filename_ext = ".mesh"
-    filepath = bpy.props.StringProperty(
+    filepath: bpy.props.StringProperty(
         name="Export mesh file",
         description="New mesh file to export to",
         maxlen= 1024,
@@ -26,9 +26,9 @@ class export_mesh(bpy.types.Operator, ExportHelper):
     )
 
     #Operator properties
-    writeSol    = bpy.props.FloatProperty(name="writeSol", description="Write the .sol if weight paints are present", default=False)
-    miniSol     = bpy.props.FloatProperty(name="miniSol",  description="Minimum scalar", default=0.01, subtype="FACTOR")
-    maxiSol     = bpy.props.FloatProperty(name="maxiSol",  description="Maximum scalar", default=1, subtype="FACTOR")
+    writeSol: bpy.props.FloatProperty(name="writeSol", description="Write the .sol if weight paints are present", default=False)
+    miniSol: bpy.props.FloatProperty(name="miniSol",  description="Minimum scalar", default=0.01, subtype="FACTOR")
+    maxiSol: bpy.props.FloatProperty(name="maxiSol",  description="Maximum scalar", default=1, subtype="FACTOR")
 
 
     @classmethod
@@ -44,7 +44,7 @@ class export_mesh(bpy.types.Operator, ExportHelper):
 
         #Duplicate the selected object and make the duplicate active
         bpy.ops.object.duplicate()
-        obj = context.scene.objects.active
+        obj = context.active_object
 
         #Convert ngons to triangles
         bpy.context.tool_settings.mesh_select_mode=(False,False,True)

--- a/src/op_MESH_import.py
+++ b/src/op_MESH_import.py
@@ -13,7 +13,7 @@ class import_mesh(bpy.types.Operator, ImportHelper):
     """Import a Mesh file"""
     bl_idname = "bakemyscan.import_mesh"
     bl_label  = "Imports a .mesh file"
-    filter_glob = bpy.props.StringProperty(
+    filter_glob: bpy.props.StringProperty(
         default="*.mesh",
         options={'HIDDEN'},
     )

--- a/src/op_REMESHERS.py
+++ b/src/op_REMESHERS.py
@@ -14,12 +14,12 @@ class Quadriflow(base.BaseRemesher):
     bl_idname = "bakemyscan.remesh_quadriflow"
     bl_label  = "Quadriflow"
 
-    resolution = bpy.props.IntProperty( name="resolution", description="Resolution", default=1000, min=10, max=100000 )
+    resolution: bpy.props.IntProperty( name="resolution", description="Resolution", default=1000, min=10, max=100000 )
 
-    advanced = bpy.props.BoolProperty(  name="advanced", description="advanced properties", default=False)
-    mincost  = bpy.props.BoolProperty( name="mincost", description="Min-Cost Flow Solver", default=False )
-    sharp    = bpy.props.BoolProperty( name="sharp", description="Preserve sharp edges", default=False )
-    satflip  = bpy.props.BoolProperty( name="satflip", description="SAT Flip Removal", default=False )
+    advanced: bpy.props.BoolProperty(  name="advanced", description="advanced properties", default=False)
+    mincost: bpy.props.BoolProperty( name="mincost", description="Min-Cost Flow Solver", default=False )
+    sharp: bpy.props.BoolProperty( name="sharp", description="Preserve sharp edges", default=False )
+    satflip: bpy.props.BoolProperty( name="satflip", description="SAT Flip Removal", default=False )
 
     def check(self, context):
         return True
@@ -61,24 +61,24 @@ class Instant(base.BaseRemesher):
     bl_idname = "bakemyscan.remesh_instant"
     bl_label  = "Instant Meshes"
 
-    interactive = bpy.props.BoolProperty(  name="interactive", description="Interactive", default=False)
-    method      = bpy.props.EnumProperty(items= ( ('faces', 'Number of faces', 'Number of faces'), ("verts", "Number of verts", "Number of verts"), ("edges", "Edge length", "Edge length")) , name="Remesh according to", description="Remesh according to", default="faces")
-    facescount  = bpy.props.IntProperty(   name="facescount",  description="Number of faces", default=5000, min=10, max=10000000 )
-    vertscount  = bpy.props.IntProperty(   name="vertscount",  description="Number of verts", default=5000, min=10, max=10000000 )
-    edgelength  = bpy.props.FloatProperty( name="edgelength",  description="Edge length (ratio)", default=0.05, min=0.001, max=1 )
+    interactive: bpy.props.BoolProperty(  name="interactive", description="Interactive", default=False)
+    method: bpy.props.EnumProperty(items= ( ('faces', 'Number of faces', 'Number of faces'), ("verts", "Number of verts", "Number of verts"), ("edges", "Edge length", "Edge length")) , name="Remesh according to", description="Remesh according to", default="faces")
+    facescount: bpy.props.IntProperty(   name="facescount",  description="Number of faces", default=5000, min=10, max=10000000 )
+    vertscount: bpy.props.IntProperty(   name="vertscount",  description="Number of verts", default=5000, min=10, max=10000000 )
+    edgelength: bpy.props.FloatProperty( name="edgelength",  description="Edge length (ratio)", default=0.05, min=0.001, max=1 )
 
-    d = bpy.props.BoolProperty( name="d", description="Deterministic (slower)", default=False)
-    D = bpy.props.BoolProperty( name="D", description="Tris/quads dominant instead of pure", default=False)
-    i = bpy.props.BoolProperty( name="i", description="Intrinsic mode", default=False)
-    b = bpy.props.BoolProperty( name="b", description="Align to boundaries", default=False)
-    C = bpy.props.BoolProperty( name="C", description="Compatibility mode", default=False)
+    d: bpy.props.BoolProperty( name="d", description="Deterministic (slower)", default=False)
+    D: bpy.props.BoolProperty( name="D", description="Tris/quads dominant instead of pure", default=False)
+    i: bpy.props.BoolProperty( name="i", description="Intrinsic mode", default=False)
+    b: bpy.props.BoolProperty( name="b", description="Align to boundaries", default=False)
+    C: bpy.props.BoolProperty( name="C", description="Compatibility mode", default=False)
 
-    c = bpy.props.FloatProperty( name="c",  description="Creases angle threshold", default=30, min=0, max=180 )
-    S = bpy.props.IntProperty(   name="S",  description="Smoothing reprojection steps", default=2, min=0, max=100 )
-    r = bpy.props.EnumProperty(items= ( ('r0', 'none', 'none'), ("2", "2", "2"), ("4", "4", "4"), ("6", "6", "6")) , name="r", description="Orientation symmetry type", default="r0")
-    p = bpy.props.EnumProperty(items= ( ('p0', 'none', 'none'), ("4", "4", "4"), ("6", "6", "6")) , name="r", description="Position symmetry type", default="p0")
+    c: bpy.props.FloatProperty( name="c",  description="Creases angle threshold", default=30, min=0, max=180 )
+    S: bpy.props.IntProperty(   name="S",  description="Smoothing reprojection steps", default=2, min=0, max=100 )
+    r: bpy.props.EnumProperty(items= ( ('r0', 'none', 'none'), ("2", "2", "2"), ("4", "4", "4"), ("6", "6", "6")) , name="r", description="Orientation symmetry type", default="r0")
+    p: bpy.props.EnumProperty(items= ( ('p0', 'none', 'none'), ("4", "4", "4"), ("6", "6", "6")) , name="r", description="Position symmetry type", default="p0")
 
-    advanced = bpy.props.BoolProperty(  name="advanced", description="advanced properties", default=False)
+    advanced: bpy.props.BoolProperty(  name="advanced", description="advanced properties", default=False)
 
     def check(self, context):
         return True
@@ -162,17 +162,17 @@ class Mmgs(base.BaseRemesher):
     bl_label  = "Mmgs"
 
     #Basic options
-    smooth = bpy.props.BoolProperty(  name="smooth", description="Ignore angle detection (smooth)", default=True)
-    hausd  = bpy.props.FloatProperty( name="hausd", description="Haussdorf distance (ratio)", default=0.01, min=0.0001, max=1)
+    smooth: bpy.props.BoolProperty(  name="smooth", description="Ignore angle detection (smooth)", default=True)
+    hausd: bpy.props.FloatProperty( name="hausd", description="Haussdorf distance (ratio)", default=0.01, min=0.0001, max=1)
     #Advanced options
-    advanced = bpy.props.BoolProperty(  name="advanced", description="advanced properties", default=False)
-    angle  = bpy.props.FloatProperty( name="hausd",  description="Angle detection (°)", default=30, min=0.01, max=180.)
-    hmin   = bpy.props.FloatProperty( name="hmin",   description="Minimal edge size (ratio)", default=0.005, min=0.0001, max=1)
-    hmax   = bpy.props.FloatProperty( name="hmax",   description="Maximal edge size (ratio)", default=0.05, min=0.0001, max=5)
-    hgrad  = bpy.props.FloatProperty( name="hgrad",  description="Gradation parameter", default=1.3, min=1., max=5.)
-    aniso  = bpy.props.BoolProperty(  name="aniso",  description="Enable anisotropy", default=False)
-    nreg   = bpy.props.BoolProperty(  name="nreg",   description="Normal regulation", default=False)
-    weight   = bpy.props.BoolProperty(  name="weight", description="weight as edge length", default=False)
+    advanced: bpy.props.BoolProperty(  name="advanced", description="advanced properties", default=False)
+    angle: bpy.props.FloatProperty( name="hausd",  description="Angle detection (°)", default=30, min=0.01, max=180.)
+    hmin: bpy.props.FloatProperty( name="hmin",   description="Minimal edge size (ratio)", default=0.005, min=0.0001, max=1)
+    hmax: bpy.props.FloatProperty( name="hmax",   description="Maximal edge size (ratio)", default=0.05, min=0.0001, max=5)
+    hgrad: bpy.props.FloatProperty( name="hgrad",  description="Gradation parameter", default=1.3, min=1., max=5.)
+    aniso: bpy.props.BoolProperty(  name="aniso",  description="Enable anisotropy", default=False)
+    nreg: bpy.props.BoolProperty(  name="nreg",   description="Normal regulation", default=False)
+    weight: bpy.props.BoolProperty(  name="weight", description="weight as edge length", default=False)
 
     def check(self, context):
         return True
@@ -241,16 +241,16 @@ class Meshlab(base.BaseRemesher):
     bl_idname = "bakemyscan.remesh_meshlab"
     bl_label  = "Meshlab"
 
-    facescount = bpy.props.IntProperty( name="facescount", description="Number of faces", default=5000, min=10, max=1000000 )
-    advanced = bpy.props.BoolProperty(  name="advanced", description="advanced properties", default=False)
-    quality    = bpy.props.FloatProperty( name="quality", description="Quality threshold", default=0.3, min=0., max=1. )
-    boundaries = bpy.props.BoolProperty( name="boundaries", description="Preserve boundary", default=False)
-    weight     = bpy.props.FloatProperty( name="weight", description="Boundary preserving weight", default=1., min=0., max=1. )
-    normals  = bpy.props.BoolProperty( name="normals", description="Preserve normals", default=False)
-    topology = bpy.props.BoolProperty( name="topology", description="Preserve topology", default=False)
-    existing = bpy.props.BoolProperty( name="existing", description="Use existing vertices", default=False)
-    planar   = bpy.props.BoolProperty( name="planar", description="Planar simplification", default=False)
-    post     = bpy.props.BoolProperty( name="post", description="Post-process (isolated, duplicates...)", default=True)
+    facescount: bpy.props.IntProperty( name="facescount", description="Number of faces", default=5000, min=10, max=1000000 )
+    advanced: bpy.props.BoolProperty(  name="advanced", description="advanced properties", default=False)
+    quality: bpy.props.FloatProperty( name="quality", description="Quality threshold", default=0.3, min=0., max=1. )
+    boundaries: bpy.props.BoolProperty( name="boundaries", description="Preserve boundary", default=False)
+    weight: bpy.props.FloatProperty( name="weight", description="Boundary preserving weight", default=1., min=0., max=1. )
+    normals: bpy.props.BoolProperty( name="normals", description="Preserve normals", default=False)
+    topology: bpy.props.BoolProperty( name="topology", description="Preserve topology", default=False)
+    existing: bpy.props.BoolProperty( name="existing", description="Use existing vertices", default=False)
+    planar: bpy.props.BoolProperty( name="planar", description="Planar simplification", default=False)
+    post: bpy.props.BoolProperty( name="post", description="Post-process (isolated, duplicates...)", default=True)
 
     def check(self, context):
         return True
@@ -319,9 +319,9 @@ class Basic(base.BaseRemesher):
     bl_label  = "Basic decimate"
     workonduplis = True
 
-    limit    = bpy.props.IntProperty(description="Target faces", default=1500, min=50, max=500000)
-    vertex_group = bpy.props.BoolProperty(description="Use vertex group", default=True)
-    factor = bpy.props.FloatProperty(description="Weight factor", default=0.5, min=0., max=1.)
+    limit: bpy.props.IntProperty(description="Target faces", default=1500, min=50, max=500000)
+    vertex_group: bpy.props.BoolProperty(description="Use vertex group", default=True)
+    factor: bpy.props.FloatProperty(description="Weight factor", default=0.5, min=0., max=1.)
 
     def draw(self, context):
         self.layout.prop(self, "limit", text="Number of faces")
@@ -344,10 +344,10 @@ class Quads(base.BaseRemesher):
     bl_label  = "Dirty quads"
     workonduplis = True
 
-    nfaces = bpy.props.IntProperty(name="nfaces",   description="Decimate ratio",  default=1500, min=50, max=200000)
-    smooth = bpy.props.IntProperty(  name="smooth", description="Smoothing steps", default=1, min=0, max=15)
-    vertex_group = bpy.props.BoolProperty(name="vertex_group", description="Use vertex group", default=True)
-    factor = bpy.props.FloatProperty(description="Weight factor", default=0.5, min=0., max=1.)
+    nfaces: bpy.props.IntProperty(name="nfaces",   description="Decimate ratio",  default=1500, min=50, max=200000)
+    smooth: bpy.props.IntProperty(  name="smooth", description="Smoothing steps", default=1, min=0, max=15)
+    vertex_group: bpy.props.BoolProperty(name="vertex_group", description="Use vertex group", default=True)
+    factor: bpy.props.FloatProperty(description="Weight factor", default=0.5, min=0., max=1.)
 
     def draw(self, context):
         self.layout.prop(self, "nfaces",  text="Number of quads (min)")
@@ -411,9 +411,9 @@ class Iterative(base.BaseRemesher):
     bl_label  = "Iterative method"
     workonduplis = True
 
-    limit    = bpy.props.IntProperty(name="limit",    description="Target faces", default=1500, min=50, max=500000)
-    vertex_group = bpy.props.BoolProperty(name="vertex_group", description="Use vertex group", default=False)
-    factor = bpy.props.FloatProperty(description="Weight factor", default=0.5, min=0., max=1.)
+    limit: bpy.props.IntProperty(name="limit",    description="Target faces", default=1500, min=50, max=500000)
+    vertex_group: bpy.props.BoolProperty(name="vertex_group", description="Use vertex group", default=False)
+    factor: bpy.props.FloatProperty(description="Weight factor", default=0.5, min=0., max=1.)
 
     def draw(self, context):
         self.layout.prop(self, "limit", text="target triangles")
@@ -470,17 +470,17 @@ class Iterative(base.BaseRemesher):
         while(iterate):
             i+=1
             print("-- Iteration %d:" % i)
-            lr = context.scene.objects.active
+            lr = context.active_object
             bpy.ops.object.duplicate()
             self.do_one_iteration()
-            tmp = context.scene.objects.active
+            tmp = context.active_object
             print("-- Iteration %d: %d tris -> %d tris" % (i, len(lr.data.polygons), len(tmp.data.polygons)) )
             if len(tmp.data.polygons) < self.limit:
                 print("-- We went far enough, cancel the last iteration")
                 iterate=False
                 bpy.data.objects.remove(tmp)
-                bpy.context.scene.objects.active = lr
-                lr.select = True
+                bpy.context.view_layer.objects.active = lr
+                lr.select_set(True)
             else:
                 bpy.data.objects.remove(lr)
         del bpy.types.Scene.hr

--- a/src/op_REMESHERS_BASE.py
+++ b/src/op_REMESHERS_BASE.py
@@ -62,7 +62,7 @@ class BaseRemesher(bpy.types.Operator):
         #Operators working on a duplicated object
         if self.workonduplis:
             bpy.ops.object.duplicate()
-            self.copiedobject = context.scene.objects.active
+            self.copiedobject = context.active_object
             #Apply the modifiers
             for m in self.copiedobject.modifiers:
                 bpy.ops.object.modifier_apply(modifier=m.name)
@@ -78,8 +78,8 @@ class BaseRemesher(bpy.types.Operator):
             self.new = newObjects[0]
             #Make it selected and active
             bpy.ops.object.select_all(action='DESELECT')
-            self.new.select=True
-            bpy.context.scene.objects.active = self.new
+            self.new.select_set(True)
+            bpy.context.view_layer.objects.active = self.new
             #Remove edges marked as sharp, and delete the loose geometry
             bpy.ops.object.editmode_toggle()
             bpy.ops.mesh.mark_sharp(clear=True)

--- a/src/op_REMESHERS_POST.py
+++ b/src/op_REMESHERS_POST.py
@@ -19,7 +19,7 @@ class Symmetry(base.BaseRemesher):
     keepMaterials = True
     hide_old      = True
 
-    center = bpy.props.EnumProperty(
+    center: bpy.props.EnumProperty(
         items= (
             ('bbox','bbox','bbox'),
             ('cursor','cursor','cursor'),
@@ -28,7 +28,7 @@ class Symmetry(base.BaseRemesher):
         description="center",
         default="bbox"
     )
-    axis = bpy.props.EnumProperty(
+    axis: bpy.props.EnumProperty(
         items= (
             ('-X','-X','-X'),
             ('+X','+X','+X'),
@@ -98,8 +98,8 @@ class Symmetry(base.BaseRemesher):
 
         #Make the original object active once again
         bpy.ops.object.select_all(action='DESELECT')
-        context.scene.objects.active = lr
-        lr.select = True
+        context.view_layer.objects.active = lr
+        lr.select_set(True)
 
         #boolean cut
         bpy.ops.object.modifier_add(type='BOOLEAN')
@@ -112,8 +112,8 @@ class Symmetry(base.BaseRemesher):
 
         #Make the original object active once again
         bpy.ops.object.select_all(action='DESELECT')
-        context.scene.objects.active = lr
-        lr.select             = True
+        context.view_layer.objects.active = lr
+        lr.select_set(True)
 
         #Add a mirror modifier
         bpy.ops.object.modifier_add(type='MIRROR')
@@ -135,8 +135,8 @@ class Symmetry(base.BaseRemesher):
         mod.mirror_object = empty
         #Make the original object active once again
         bpy.ops.object.select_all(action='DESELECT')
-        context.scene.objects.active = lr
-        lr.select             = True
+        context.view_layer.objects.active = lr
+        lr.select.set(True)
         #Apply
         bpy.ops.object.modifier_apply(apply_as='DATA', modifier="Mirror")
         #Remove the empty
@@ -153,8 +153,8 @@ class Symmetry(base.BaseRemesher):
 
         #Make the original object active once again
         bpy.ops.object.select_all(action='DESELECT')
-        context.scene.objects.active = lr
-        lr.select              = True
+        context.view_layer.objects.active = lr
+        lr.select_set(True)
 
         return {"FINISHED"}
 
@@ -167,7 +167,7 @@ class Relax(base.BaseRemesher):
     keepMaterials = True
     hide_old      = True
 
-    smooth = bpy.props.IntProperty(  name="smooth", description="Relaxation steps", default=2, min=0, max=150)
+    smooth: bpy.props.IntProperty(  name="smooth", description="Relaxation steps", default=2, min=0, max=150)
 
     def draw(self, context):
         self.layout.prop(self, "smooth", text="Relaxation steps")
@@ -192,8 +192,8 @@ class Relax(base.BaseRemesher):
 
         #Make the original object active once again
         bpy.ops.object.select_all(action='DESELECT')
-        context.scene.objects.active = lr
-        lr.select              = True
+        context.view_layer.objects.active = lr
+        lr.select_set(True)
 
         #Hide the original object?
         #hr.hide = True
@@ -210,7 +210,7 @@ class Manifold(base.BaseRemesher):
     keepMaterials = True
     hide_old      = True
 
-    manifold_method = bpy.props.EnumProperty(
+    manifold_method: bpy.props.EnumProperty(
         items= (
             ('print3d', '3D print toolbox', ''),
             ('manifold', 'Manifold', ''),

--- a/src/op_SCAN.py
+++ b/src/op_SCAN.py
@@ -15,12 +15,12 @@ class colmap_auto(bpy.types.Operator):
     bl_options = {"REGISTER"}
 
 
-    mesher  = bpy.props.EnumProperty(items= ( ('delaunay', 'delaunay', 'delaunay'), ("poisson", "poisson", "poisson")) , description="Mesher", default="delaunay")
-    quality = bpy.props.EnumProperty(items= ( ('low', 'low', 'low'), ("medium", "medium", "medium"), ("high", "high", "high")) , description="Quality", default="medium")
-    sparse = bpy.props.BoolProperty(description="Sparse", default=True)
-    dense  = bpy.props.BoolProperty(description="Dense", default=True)
-    single = bpy.props.BoolProperty(description="Single Camera", default=True)
-    gpu    = bpy.props.BoolProperty(description="GPU", default=True)
+    mesher: bpy.props.EnumProperty(items= ( ('delaunay', 'delaunay', 'delaunay'), ("poisson", "poisson", "poisson")) , description="Mesher", default="delaunay")
+    quality: bpy.props.EnumProperty(items= ( ('low', 'low', 'low'), ("medium", "medium", "medium"), ("high", "high", "high")) , description="Quality", default="medium")
+    sparse: bpy.props.BoolProperty(description="Sparse", default=True)
+    dense: bpy.props.BoolProperty(description="Dense", default=True)
+    single: bpy.props.BoolProperty(description="Single Camera", default=True)
+    gpu: bpy.props.BoolProperty(description="GPU", default=True)
 
     def check(self, context):
         return True
@@ -74,12 +74,12 @@ class colmap_openmvs(bpy.types.Operator):
     bl_options = {"REGISTER"}
 
 
-    single = bpy.props.BoolProperty(description="Single Camera", default=True)
-    gpu    = bpy.props.BoolProperty(description="GPU", default=True)
-    reconstruct_distance = bpy.props.FloatProperty(description="Pixel distance", default=2.5, min=1., max=20.)
-    texture_resolution = bpy.props.IntProperty(description="Scale factor for texturing", default=2, min=0, max=5)
-    densify_resolution=bpy.props.IntProperty(description="Scale factor for densifying", default=2, min=0, max=5)
-    min_size=bpy.props.IntProperty(description="Minimal texture size", default=640, min=128, max=4096)
+    single: bpy.props.BoolProperty(description="Single Camera", default=True)
+    gpu: bpy.props.BoolProperty(description="GPU", default=True)
+    reconstruct_distance: bpy.props.FloatProperty(description="Pixel distance", default=2.5, min=1., max=20.)
+    texture_resolution: bpy.props.IntProperty(description="Scale factor for texturing", default=2, min=0, max=5)
+    densify_resolution: bpy.props.IntProperty(description="Scale factor for densifying", default=2, min=0, max=5)
+    min_size: bpy.props.IntProperty(description="Minimal texture size", default=640, min=128, max=4096)
 
     def check(self, context):
         return True

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -161,9 +161,9 @@ if __name__ == "__main__":
         sys.exit(2)
     #Set the executables in the addon user preferences
     try:
-        bpy.context.user_preferences.addons["BakeMyScan"].preferences.mmgs          = args.mmgs
-        bpy.context.user_preferences.addons["BakeMyScan"].preferences.instant       = args.instant
-        bpy.context.user_preferences.addons["BakeMyScan"].preferences.meshlabserver = args.meshlabserver
+        bpy.context.preferences.addons["BakeMyScan"].preferences.mmgs          = args.mmgs
+        bpy.context.preferences.addons["BakeMyScan"].preferences.instant       = args.instant
+        bpy.context.preferences.addons["BakeMyScan"].preferences.meshlabserver = args.meshlabserver
         bpy.types.Scene.executables["mmgs"] = args.mmgs
         bpy.types.Scene.executables["instant"] = args.instant
         bpy.types.Scene.executables["meshlabserver"] = args.meshlabserver
@@ -197,7 +197,7 @@ if __name__ == "__main__":
         source = bpy.data.objects["Suzanne"]
         bpy.ops.mesh.primitive_monkey_add(calc_uvs=True)
         target = bpy.context.active_object
-        source.select = True
+        source.select_set(True)
 
     def assert_model_imported():
         assert(len(bpy.data.objects) == 1)


### PR DESCRIPTION
Hi there! This addon is awesome! I spent a few hours today seeing if I could update it to work in 2.80, and I got fairly far. I thought I would just PR it and see what your thoughts were.

The biggest difficulty seems to be in the actual baking, since a lot of the functionality in the original addon depends on Blender's internal render engine, which has been significantly deprecated in 2.80. 

Specifically, I ran into trouble with the addon's usage of a material's texture_slots in the bakeWithBlender function. I played around with adjusting the function, but ultimately I fear the paradigm has fundamentally changed, and programmatic access to the material is really only possible via the Nodes APIs. Instead of tearing apart the `op_BAKING_bake.py` file I decided to just hook in a new file that I called `op_BAKING_bake_nodes.py`. I attached a new button for this operator which I labeled "Bake textures w Nodes". 

All of that work is really just an experiment to test that it would still work in 2.80. I'm in over my head a bit with the PBR-based baking, so I think I would need help porting it all over in a good state.

Hopefully this is a start, though!

PS - I work at Ubiquity6. We make display.land. You should check out some of our open positions - we're basically making a free, full version of BakeMyScan in a product with thousands of users.